### PR TITLE
Remove possibility of additional fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nxcd/paradox",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/classes/EventEntity.ts
+++ b/src/classes/EventEntity.ts
@@ -2,7 +2,6 @@ import { IEvent, Reducer, ICommitFunction } from '@nxcd/tardis'
 import { IEventEntity } from '../interfaces/IEventEntity'
 
 export abstract class EventEntity<TEntity> implements IEventEntity {
-  [key: string]: any
   persistedEvents: IEvent<any>[] = []
   pendingEvents: IEvent<any>[] = []
   id: any = null


### PR DESCRIPTION
This property signature is useless since users don't directly implement this class, they must extend it, so this property becomes completely pointless.

This should not break anything since it is not actually used.

Closes #5