### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@nxcd/paradox",
   "version": "2.10.1",
   "description": "",
+  "repository": "github:nxcd/paradox",
   "main": "dist/index.js",
   "scripts": {
     "prepublish": "npm run build:clean",


### PR DESCRIPTION
I noted the NPM page (https://www.npmjs.com/package/@nxcd/paradox) was missing the link to the repository. I think this PR fixes that.