### PR TITLE
Repository override

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ class PersonRepository extends MongodbEventRepository<Person> {
 
 **Methods**:
 
-- *public* `save(entity: BusinessEntity)`: Saves the current entity to the database
+- *public* `save(entity: BusinessEntity, force: Boolean = false)`: Saves the current entity to the database by either pushing new events, or overriding the events array **(Be VERY carefull with the last one)**
 - *public* `bulkUpdate(entities: EventEntity[], session)`: Updates multiple entities at once
 - *public* `bulkInsert(entities: EventEntity[], session)`: Inserts multiple entities at once
 - *public* `findById(id: string | ObjectId)`: Finds an entity by the provided ID
@@ -283,7 +283,7 @@ Repositories are places where data resides, by default, we would not have to cre
 
 Since different databases have different event sourcing implementations, for now, we only have the ones listed below.
 
-> Note that different repository classes might behave differently depending on who created the class, please refer to the PR section or fill in an issue if you're experiencing troubles.
+> Note that different repository classes might behave differently depending on who created the class, please refer to the PR section or fill in an issue if you're experiencing trouble.
 
 - [MongoDB event-based repository](./docs/MongodbEventRepository.md)
 
@@ -367,7 +367,7 @@ Those are the required implementations, any additional functionalities you'd lik
 If you'd like to add your repository to the list of included repositories, please fill in a PR and don't forget to stick to some conventions:
 
 - All names are CamelCase
-- Private variables come with an `_` preceding it
+- Private methods start their names with `_`
 - Do **not** forget to add the documentation to this repository in the `docs/` folder (the file should be the same name as your class)
 - Do **not** forget to add your repository to the list in this README along with the link to its own docs
 

--- a/docs/MongodbEventRepository.md
+++ b/docs/MongodbEventRepository.md
@@ -13,10 +13,12 @@ Data repository made for MongoDB databases. This repository **must** be extended
 
 By default, the class already has some base methods:
 
-- `save (entity: TEntity)`: Which will serialize and save the received entity (which must be of the same type you passed to the generic type `TEntity` in `MongodbEventRepository<TEntity>`) on the database.
+- `save (entity: TEntity, force: Boolean = false)`: Which will serialize and save the received entity (which must be of the same type you passed to the generic type `TEntity` in `MongodbEventRepository<TEntity>`) on the database.
 
-> This method works by firstly trying to find the entity by its ID, if the ID cannot be found in the database, then a new document will be created, following the `{_id, events, state}` format where `events` should start as an empty array and, at each `save`, the `pendingEvents` array will be merged to it. Soon after that, the `confirmEvents` method will be called, thus clearing the `pendingEvents` array.
->
+> This method works by firstly trying to find the entity by its ID, if the ID cannot be found in the database, then a new document will be created, following the `{_id, events, state}` format where `events` should start as an empty array and, by default, at each `save`, the `pendingEvents` array will be merged to it; the `force` option, explained below, changes this saving behaviour. Soon after that, the `confirmEvents` method will be called, thus clearing the `pendingEvents` array.
+
+> The `force` option changes the behaviour stated above. When this flag is set to `true`, the repository will not append the `pendingEvents` array to the end of the database `events` array. Instead, it'll override the whole saved events array; so be  **_really_** careful when using this option. For instance, misusing this could lead to data loss on concurrent write scenarios. Consider this as rewriting the history of a git repository with a `push --force`: it's there, it can be done, but, in most situations, you really shouldn't.
+
 > `state` will be the last reduced state of the entity, which will be obtained by calling the `state` getter we just defined earlier.
 
 - `findById (id: ObjectId)`: Will search in the database for a record with the informed `id`.

--- a/src/classes/EventEntity.ts
+++ b/src/classes/EventEntity.ts
@@ -25,6 +25,13 @@ export abstract class EventEntity<TEntity> implements IEventEntity {
     }
   }
 
+  get events () {
+    return [
+      ...this.persistedEvents,
+      ...this.pendingEvents
+    ]
+  }
+
   setPersistedEvents (events: IEvent<any>[]) {
     this.persistedEvents = events
     this.updateState()

--- a/src/classes/repositories/MongodbEventRepository.ts
+++ b/src/classes/repositories/MongodbEventRepository.ts
@@ -54,16 +54,15 @@ export abstract class MongodbEventRepository<TEntity extends IEventEntity> exten
    * Creates or updates an entity in the database
    * @param {TEntity} entity Entity to be saved (upserted) to the bank
    */
-  async save (entity: TEntity): Promise<TEntity> {
-    const { state, pendingEvents } = entity
+  async save (entity: TEntity, force: Boolean = false): Promise<TEntity> {
+    const { state, events, pendingEvents } = entity
     const document = await this.findById(entity.id)
 
     if (!document) return this._create(entity)
 
-    const operations = {
-      $set: { state },
-      $push: { events: { $each: pendingEvents } }
-    }
+    const operations = force
+      ? { $set: { state, events } }
+      : { $set: { state }, $push: { events: { $each: pendingEvents } } }
 
     await this._collection.updateOne({ _id: new ObjectId(entity.id) }, operations)
 

--- a/src/interfaces/IEventEntity.ts
+++ b/src/interfaces/IEventEntity.ts
@@ -3,6 +3,7 @@ import { IEvent } from '@nxcd/tardis'
 export interface IEventEntity {
   id: any
   state: any
+  events: IEvent<any>[]
   persistedEvents: IEvent<any>[]
   pendingEvents: IEvent<any>[]
   /**


### PR DESCRIPTION
Allow users to override the whole event array of a document by passing a `force: Boolean` second parameter to `MongoDbEventRepository`'s `save` method.

Intented for database maintenece