### PR TITLE
Add support for segregating an entity's state and events between two different collections

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@nxcd/tardis": "^2.0.1"
   },
   "devDependencies": {
-    "@types/mongodb": "^3.1.12",
+    "@types/mongodb": "^3.1.22",
     "@types/node": "^10.12.0",
     "standard": "^12.0.1",
     "typescript": "^3.1.3"

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,7 +1,7 @@
 dependencies:
   '@nxcd/tardis': 2.0.1
 devDependencies:
-  '@types/mongodb': 3.1.21
+  '@types/mongodb': 3.1.22
   '@types/node': 10.12.30
   standard: 12.0.1
   typescript: 3.3.3333
@@ -31,13 +31,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-9IdED8wU93ty8gP06ninox+42SBSJHp2IAamsSYMUY76mshRTeUsid/gtbl8ovnOwy8im41ib4cxTiIYMXGKew==
-  /@types/mongodb/3.1.21:
+  /@types/mongodb/3.1.22:
     dependencies:
       '@types/bson': 4.0.0
       '@types/node': 10.12.30
     dev: true
     resolution:
-      integrity: sha512-V1W/OFjUdz8xeVetg37eF1tpC+4y60YAn5pgB1pGW58oxNwNw/gU/k7EaUFXTVUTwKS6Ot6Ui6xEm60ZD4zCAg==
+      integrity: sha512-hvNR0txBlJJAy1eZOeIDshW4dnQaC694COou4eHHaMdIcteCfoCQATD7sYNlXxNxfTc1iIbHUi7A8CAhQe08uA==
   /@types/node/10.12.30:
     resolution:
       integrity: sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==
@@ -1468,7 +1468,7 @@ shrinkwrapMinorVersion: 9
 shrinkwrapVersion: 3
 specifiers:
   '@nxcd/tardis': ^2.0.1
-  '@types/mongodb': ^3.1.12
+  '@types/mongodb': ^3.1.22
   '@types/node': ^10.12.0
   standard: ^12.0.1
   typescript: ^3.1.3

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1,69 +1,72 @@
 dependencies:
   '@nxcd/tardis': 2.0.1
 devDependencies:
-  '@types/mongodb': 3.1.12
-  '@types/node': 10.12.0
+  '@types/mongodb': 3.1.21
+  '@types/node': 10.12.30
   standard: 12.0.1
-  typescript: 3.1.3
+  typescript: 3.3.3333
 packages:
   /@nxcd/tardis/2.0.1:
     dependencies:
-      '@types/lodash.clonedeep': 4.5.4
-      '@types/node': 10.12.0
+      '@types/lodash.clonedeep': 4.5.6
+      '@types/node': 10.12.30
       bson-objectid: 1.2.4
       lodash.clonedeep: 4.5.0
     dev: false
     resolution:
       integrity: sha512-qhR2vAWeufcbCAeYa9L8kRlq20NdYgSicN4e9sGfDfM3Q6UrcT/OmAU+nUu6ERhOQFhKtvPu956ZgLT29Pd6tw==
-  /@types/bson/1.0.11:
+  /@types/bson/4.0.0:
     dependencies:
-      '@types/node': 10.12.0
+      '@types/node': 10.12.30
     dev: true
     resolution:
-      integrity: sha512-j+UcCWI+FsbI5/FQP/Kj2CXyplWAz39ktHFkXk84h7dNblKRSoNJs95PZFRd96NQGqsPEPgeclqnznWZr14ZDA==
-  /@types/lodash.clonedeep/4.5.4:
+      integrity: sha512-pq/rqJwJWkbS10crsG5bgnrisL8pML79KlMKQMoQwLUjlPAkrUHMvHJ3oGwE7WHR61Lv/nadMwXVAD2b+fpD8Q==
+  /@types/lodash.clonedeep/4.5.6:
     dependencies:
-      '@types/lodash': 4.14.117
+      '@types/lodash': 4.14.122
     dev: false
     resolution:
-      integrity: sha512-+rCVPIZOJaub++wU/lmyp/SxiKlqXQaXI5LryzjuHBKFj51ApVt38Xxk9psLWNGMuR/obEQNTH0l/yDfG4ANNQ==
-  /@types/lodash/4.14.117:
+      integrity: sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  /@types/lodash/4.14.122:
     dev: false
     resolution:
-      integrity: sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==
-  /@types/mongodb/3.1.12:
+      integrity: sha512-9IdED8wU93ty8gP06ninox+42SBSJHp2IAamsSYMUY76mshRTeUsid/gtbl8ovnOwy8im41ib4cxTiIYMXGKew==
+  /@types/mongodb/3.1.21:
     dependencies:
-      '@types/bson': 1.0.11
-      '@types/node': 10.12.0
+      '@types/bson': 4.0.0
+      '@types/node': 10.12.30
     dev: true
     resolution:
-      integrity: sha512-HKacBlbypwL3qR/W9o5G+3zCAcfLY2Wva1Ttq7u2y5HnkX20Huz8uNYnjo14eQeuOUyt8YZf963h2m64ajg5fA==
-  /@types/node/10.12.0:
+      integrity: sha512-V1W/OFjUdz8xeVetg37eF1tpC+4y60YAn5pgB1pGW58oxNwNw/gU/k7EaUFXTVUTwKS6Ot6Ui6xEm60ZD4zCAg==
+  /@types/node/10.12.30:
     resolution:
-      integrity: sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
-  /acorn-jsx/4.1.1:
+      integrity: sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==
+  /acorn-jsx/5.0.1/acorn@6.1.1:
     dependencies:
-      acorn: 5.7.3
+      acorn: 6.1.1
     dev: true
+    id: registry.npmjs.org/acorn-jsx/5.0.1
+    peerDependencies:
+      acorn: ^6.0.0
     resolution:
-      integrity: sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==
-  /acorn/5.7.3:
+      integrity: sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+  /acorn/6.1.1:
     dev: true
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-  /ajv-keywords/3.2.0/ajv@6.5.4:
+      integrity: sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+  /ajv-keywords/3.4.0/ajv@6.10.0:
     dependencies:
-      ajv: 6.5.4
+      ajv: 6.10.0
     dev: true
-    id: registry.npmjs.org/ajv-keywords/3.2.0
+    id: registry.npmjs.org/ajv-keywords/3.4.0
     peerDependencies:
-      ajv: ^6.0.0
+      ajv: ^6.9.1
     resolution:
-      integrity: sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
-  /ajv/6.5.4:
+      integrity: sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==
+  /ajv/6.10.0:
     dependencies:
       fast-deep-equal: 2.0.1
       fast-json-stable-stringify: 2.0.0
@@ -71,13 +74,13 @@ packages:
       uri-js: 4.2.2
     dev: true
     resolution:
-      integrity: sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==
-  /ansi-escapes/3.1.0:
+      integrity: sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  /ansi-escapes/3.2.0:
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
+      integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
   /ansi-regex/2.1.1:
     dev: true
     engines:
@@ -113,32 +116,12 @@ packages:
   /array-includes/3.0.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.12.0
+      es-abstract: 1.13.0
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=
-  /array-union/1.0.2:
-    dependencies:
-      array-uniq: 1.0.3
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
-  /array-uniq/1.0.3:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
-  /arrify/1.0.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
   /babel-code-frame/6.26.0:
     dependencies:
       chalk: 1.1.3
@@ -162,12 +145,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-z511nO3HgvLpB0Ax2+kfM2HRfgGKB0VbMnRKh5yNM9Eoh2o1/DRFXBrsoTpvjR09vNIHUMUmcwFFYhSU+0PBGQ==
-  /builtin-modules/1.1.1:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
   /caller-path/0.1.0:
     dependencies:
       callsites: 0.2.0
@@ -194,8 +171,7 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-      tarball: 'http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz'
-  /chalk/2.4.1:
+  /chalk/2.4.2:
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
@@ -204,12 +180,13 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+      integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   /chardet/0.4.2:
     dev: true
     resolution:
       integrity: sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
   /circular-json/0.3.3:
+    deprecated: 'CircularJSON is in maintenance only, flatted is its successor.'
     dev: true
     resolution:
       integrity: sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
@@ -281,7 +258,7 @@ packages:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
   /define-properties/1.1.3:
     dependencies:
-      object-keys: 1.0.12
+      object-keys: 1.1.0
     dev: true
     engines:
       node: '>= 0.4'
@@ -298,20 +275,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==
-  /del/2.2.2:
-    dependencies:
-      globby: 5.0.0
-      is-path-cwd: 1.0.0
-      is-path-in-cwd: 1.0.1
-      object-assign: 4.1.1
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-      rimraf: 2.6.2
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=
   /doctrine/1.5.0:
     dependencies:
       esutils: 2.0.2
@@ -335,18 +298,19 @@ packages:
     dev: true
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.12.0:
+  /es-abstract/1.13.0:
     dependencies:
       es-to-primitive: 1.2.0
       function-bind: 1.1.1
       has: 1.0.3
       is-callable: 1.1.4
       is-regex: 1.0.4
+      object-keys: 1.1.0
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==
+      integrity: sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
   /es-to-primitive/1.2.0:
     dependencies:
       is-callable: 1.1.4
@@ -394,20 +358,20 @@ packages:
   /eslint-import-resolver-node/0.3.2:
     dependencies:
       debug: 2.6.9
-      resolve: 1.8.1
+      resolve: 1.10.0
     dev: true
     resolution:
       integrity: sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==
-  /eslint-module-utils/2.2.0:
+  /eslint-module-utils/2.3.0:
     dependencies:
       debug: 2.6.9
-      pkg-dir: 1.0.0
+      pkg-dir: 2.0.0
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=
-  /eslint-plugin-es/1.3.1/eslint@5.4.0:
+      integrity: sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
+  /eslint-plugin-es/1.4.0/eslint@5.4.0:
     dependencies:
       eslint: 5.4.0
       eslint-utils: 1.3.1
@@ -415,11 +379,11 @@ packages:
     dev: true
     engines:
       node: '>=6.5.0'
-    id: registry.npmjs.org/eslint-plugin-es/1.3.1
+    id: registry.npmjs.org/eslint-plugin-es/1.4.0
     peerDependencies:
       eslint: '>=4.19.1'
     resolution:
-      integrity: sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==
+      integrity: sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==
   /eslint-plugin-import/2.14.0/eslint@5.4.0:
     dependencies:
       contains-path: 0.1.0
@@ -427,12 +391,12 @@ packages:
       doctrine: 1.5.0
       eslint: 5.4.0
       eslint-import-resolver-node: 0.3.2
-      eslint-module-utils: 2.2.0
+      eslint-module-utils: 2.3.0
       has: 1.0.3
       lodash: 4.17.11
       minimatch: 3.0.4
       read-pkg-up: 2.0.0
-      resolve: 1.8.1
+      resolve: 1.10.0
     dev: true
     engines:
       node: '>=4'
@@ -444,11 +408,11 @@ packages:
   /eslint-plugin-node/7.0.1/eslint@5.4.0:
     dependencies:
       eslint: 5.4.0
-      eslint-plugin-es: /eslint-plugin-es/1.3.1/eslint@5.4.0
+      eslint-plugin-es: /eslint-plugin-es/1.4.0/eslint@5.4.0
       eslint-utils: 1.3.1
       ignore: 4.0.6
       minimatch: 3.0.4
-      resolve: 1.8.1
+      resolve: 1.10.0
       semver: 5.6.0
     dev: true
     engines:
@@ -471,7 +435,7 @@ packages:
       eslint: 5.4.0
       has: 1.0.3
       jsx-ast-utils: 2.0.1
-      prop-types: 15.6.2
+      prop-types: 15.7.2
     dev: true
     engines:
       node: '>=4'
@@ -489,7 +453,7 @@ packages:
       eslint: '>=5.0.0'
     resolution:
       integrity: sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==
-  /eslint-scope/4.0.0:
+  /eslint-scope/4.0.2:
     dependencies:
       esrecurse: 4.2.1
       estraverse: 4.2.0
@@ -497,7 +461,7 @@ packages:
     engines:
       node: '>=4.0.0'
     resolution:
-      integrity: sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==
+      integrity: sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==
   /eslint-utils/1.3.1:
     dev: true
     engines:
@@ -512,27 +476,27 @@ packages:
       integrity: sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
   /eslint/5.4.0:
     dependencies:
-      ajv: 6.5.4
+      ajv: 6.10.0
       babel-code-frame: 6.26.0
-      chalk: 2.4.1
+      chalk: 2.4.2
       cross-spawn: 6.0.5
       debug: 3.2.6
       doctrine: 2.1.0
-      eslint-scope: 4.0.0
+      eslint-scope: 4.0.2
       eslint-utils: 1.3.1
       eslint-visitor-keys: 1.0.0
-      espree: 4.0.0
+      espree: 4.1.0
       esquery: 1.0.1
       esutils: 2.0.2
       file-entry-cache: 2.0.0
       functional-red-black-tree: 1.0.1
       glob: 7.1.3
-      globals: 11.8.0
+      globals: 11.11.0
       ignore: 4.0.6
       imurmurhash: 0.1.4
       inquirer: 5.2.0
       is-resolvable: 1.1.0
-      js-yaml: 3.12.0
+      js-yaml: 3.12.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
       lodash: 4.17.11
@@ -542,7 +506,7 @@ packages:
       optionator: 0.8.2
       path-is-inside: 1.0.2
       pluralize: 7.0.0
-      progress: 2.0.1
+      progress: 2.0.3
       regexpp: 2.0.1
       require-uncached: 1.0.3
       semver: 5.6.0
@@ -556,15 +520,16 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==
-  /espree/4.0.0:
+  /espree/4.1.0:
     dependencies:
-      acorn: 5.7.3
-      acorn-jsx: 4.1.1
+      acorn: 6.1.1
+      acorn-jsx: /acorn-jsx/5.0.1/acorn@6.1.1
+      eslint-visitor-keys: 1.0.0
     dev: true
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==
+      integrity: sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==
   /esprima/4.0.1:
     dev: true
     engines:
@@ -610,7 +575,6 @@ packages:
       node: '>=0.12'
     resolution:
       integrity: sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
-      tarball: 'http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz'
   /fast-deep-equal/2.0.1:
     dev: true
     resolution:
@@ -633,7 +597,7 @@ packages:
       integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   /file-entry-cache/2.0.0:
     dependencies:
-      flat-cache: 1.3.0
+      flat-cache: 1.3.4
       object-assign: 4.1.1
     dev: true
     engines:
@@ -644,15 +608,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
-  /find-up/1.1.2:
-    dependencies:
-      path-exists: 2.1.0
-      pinkie-promise: 2.0.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
   /find-up/2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -661,17 +616,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
-  /flat-cache/1.3.0:
+  /flat-cache/1.3.4:
     dependencies:
       circular-json: 0.3.3
-      del: 2.2.2
-      graceful-fs: 4.1.11
+      graceful-fs: 4.1.15
+      rimraf: 2.6.3
       write: 0.2.1
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=
+      integrity: sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==
   /fs.realpath/1.0.0:
     dev: true
     resolution:
@@ -701,31 +656,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
-  /globals/11.8.0:
+  /globals/11.11.0:
     dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==
-  /globby/5.0.0:
-    dependencies:
-      array-union: 1.0.2
-      arrify: 1.0.1
-      glob: 7.1.3
-      object-assign: 4.1.1
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
+      integrity: sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
+  /graceful-fs/4.1.15:
     dev: true
-    engines:
-      node: '>=0.10.0'
     resolution:
-      integrity: sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=
-  /graceful-fs/4.1.11:
-    dev: true
-    engines:
-      node: '>=0.4.0'
-    resolution:
-      integrity: sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+      integrity: sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
   /has-ansi/2.0.0:
     dependencies:
       ansi-regex: 2.1.1
@@ -795,8 +735,8 @@ packages:
       integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
   /inquirer/5.2.0:
     dependencies:
-      ansi-escapes: 3.1.0
-      chalk: 2.4.1
+      ansi-escapes: 3.2.0
+      chalk: 2.4.2
       cli-cursor: 2.1.0
       cli-width: 2.2.0
       external-editor: 2.2.0
@@ -813,20 +753,10 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==
-      tarball: 'http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz'
   /is-arrayish/0.2.1:
     dev: true
     resolution:
       integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
-  /is-builtin-module/1.0.0:
-    dependencies:
-      builtin-modules: 1.1.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-VAVy0096wxGfj3bDDLwbHgN6/74=
-      tarball: 'http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz'
   /is-callable/1.1.4:
     dev: true
     engines:
@@ -845,28 +775,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
-  /is-path-cwd/1.0.0:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
-  /is-path-in-cwd/1.0.1:
-    dependencies:
-      is-path-inside: 1.0.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
-  /is-path-inside/1.0.1:
-    dependencies:
-      path-is-inside: 1.0.2
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-jvW33lBDej/cprToZe96pVy0gDY=
   /is-promise/2.1.0:
     dev: true
     resolution:
@@ -907,14 +815,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-  /js-yaml/3.12.0:
+  /js-yaml/3.12.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+      integrity: sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
   /json-parse-better-errors/1.0.2:
     dev: true
     resolution:
@@ -946,7 +854,7 @@ packages:
       integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   /load-json-file/2.0.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.1.15
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -955,10 +863,9 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
-      tarball: 'http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz'
   /load-json-file/4.0.0:
     dependencies:
-      graceful-fs: 4.1.11
+      graceful-fs: 4.1.15
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -1007,12 +914,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-      tarball: 'http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz'
   /minimist/1.2.0:
     dev: true
     resolution:
       integrity: sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-      tarball: 'http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz'
   /mkdirp/0.5.1:
     dependencies:
       minimist: 0.0.8
@@ -1020,7 +925,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-      tarball: 'http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz'
   /ms/2.0.0:
     dev: true
     resolution:
@@ -1041,27 +945,27 @@ packages:
     dev: true
     resolution:
       integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-  /normalize-package-data/2.4.0:
+  /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.7.1
-      is-builtin-module: 1.0.0
+      resolve: 1.10.0
       semver: 5.6.0
       validate-npm-package-license: 3.0.4
     dev: true
     resolution:
-      integrity: sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
+      integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
   /object-assign/4.1.1:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-  /object-keys/1.0.12:
+  /object-keys/1.1.0:
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+      integrity: sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -1134,14 +1038,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /path-exists/2.1.0:
-    dependencies:
-      pinkie-promise: 2.0.1
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
   /path-exists/3.0.0:
     dev: true
     engines:
@@ -1188,20 +1084,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
-  /pinkie-promise/2.0.1:
-    dependencies:
-      pinkie: 2.0.4
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-ITXW36ejWMBprJsXh3YogihFD/o=
-  /pinkie/2.0.4:
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
   /pkg-conf/2.1.0:
     dependencies:
       find-up: 2.1.0
@@ -1221,14 +1103,14 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=
-  /pkg-dir/1.0.0:
+  /pkg-dir/2.0.0:
     dependencies:
-      find-up: 1.1.2
+      find-up: 2.1.0
     dev: true
     engines:
-      node: '>=0.10.0'
+      node: '>=4'
     resolution:
-      integrity: sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
+      integrity: sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   /pluralize/7.0.0:
     dev: true
     engines:
@@ -1241,25 +1123,30 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-  /progress/2.0.1:
+  /progress/2.0.3:
     dev: true
     engines:
       node: '>=0.4.0'
     resolution:
-      integrity: sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
-  /prop-types/15.6.2:
+      integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+  /prop-types/15.7.2:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+      react-is: 16.8.4
     dev: true
     resolution:
-      integrity: sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+      integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   /punycode/2.1.1:
     dev: true
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  /react-is/16.8.4:
+    dev: true
+    resolution:
+      integrity: sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
   /read-pkg-up/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -1272,7 +1159,7 @@ packages:
   /read-pkg/2.0.0:
     dependencies:
       load-json-file: 2.0.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.5.0
       path-type: 2.0.0
     dev: true
     engines:
@@ -1300,12 +1187,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
-  /resolve/1.8.1:
+  /resolve/1.10.0:
     dependencies:
       path-parse: 1.0.6
     dev: true
     resolution:
-      integrity: sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
+      integrity: sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
   /restore-cursor/2.0.0:
     dependencies:
       onetime: 2.0.1
@@ -1315,13 +1202,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
-  /rimraf/2.6.2:
+  /rimraf/2.6.3:
     dependencies:
       glob: 7.1.3
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
+      integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   /run-async/2.3.0:
     dependencies:
       is-promise: 2.1.0
@@ -1377,13 +1264,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==
-  /spdx-correct/3.0.2:
+  /spdx-correct/3.1.0:
     dependencies:
       spdx-expression-parse: 3.0.0
-      spdx-license-ids: 3.0.1
+      spdx-license-ids: 3.0.3
     dev: true
     resolution:
-      integrity: sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==
+      integrity: sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
   /spdx-exceptions/2.2.0:
     dev: true
     resolution:
@@ -1391,14 +1278,14 @@ packages:
   /spdx-expression-parse/3.0.0:
     dependencies:
       spdx-exceptions: 2.2.0
-      spdx-license-ids: 3.0.1
+      spdx-license-ids: 3.0.3
     dev: true
     resolution:
       integrity: sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  /spdx-license-ids/3.0.1:
+  /spdx-license-ids/3.0.3:
     dev: true
     resolution:
-      integrity: sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==
+      integrity: sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
   /sprintf-js/1.0.3:
     dev: true
     resolution:
@@ -1446,7 +1333,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-      tarball: 'http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz'
   /strip-ansi/4.0.0:
     dependencies:
       ansi-regex: 3.0.0
@@ -1489,9 +1375,9 @@ packages:
       integrity: sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
   /table/4.0.3:
     dependencies:
-      ajv: 6.5.4
-      ajv-keywords: /ajv-keywords/3.2.0/ajv@6.5.4
-      chalk: 2.4.1
+      ajv: 6.10.0
+      ajv-keywords: /ajv-keywords/3.4.0/ajv@6.10.0
+      chalk: 2.4.2
       lodash: 4.17.11
       slice-ansi: 1.0.0
       string-width: 2.1.1
@@ -1500,7 +1386,6 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==
-      tarball: 'http://registry.npmjs.org/table/-/table-4.0.3.tgz'
   /text-table/0.2.0:
     dev: true
     resolution:
@@ -1509,7 +1394,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-      tarball: 'http://registry.npmjs.org/through/-/through-2.3.8.tgz'
   /tmp/0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -1526,13 +1410,13 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
-  /typescript/3.1.3:
+  /typescript/3.3.3333:
     dev: true
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
+      integrity: sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
   /uniq/1.0.1:
     dev: true
     resolution:
@@ -1545,7 +1429,7 @@ packages:
       integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   /validate-npm-package-license/3.0.4:
     dependencies:
-      spdx-correct: 3.0.2
+      spdx-correct: 3.1.0
       spdx-expression-parse: 3.0.0
     dev: true
     resolution:

--- a/src/classes/SegregatedEventEntity.ts
+++ b/src/classes/SegregatedEventEntity.ts
@@ -1,0 +1,22 @@
+import { EventEntity } from './EventEntity'
+import { Reducer, ICommitFunction } from '@nxcd/tardis'
+import { ISegregatedEvent } from '../interfaces/ISegregatedEvent'
+
+export abstract class SegregatedEventEntity<TEntity> extends EventEntity<TEntity> {
+  persistedEvents: ISegregatedEvent<any>[] = []
+  pendingEvents: ISegregatedEvent<any>[] = []
+
+  constructor (knownEvents: { [ eventName: string ]: ICommitFunction<TEntity, ISegregatedEvent<any>> }) {
+    super(knownEvents)
+    this.reducer = new Reducer<TEntity>(knownEvents)
+  }
+
+  setPersistedEvents (events: ISegregatedEvent<any>[]) {
+    return super.setPersistedEvents(events)
+  }
+
+  pushNewEvents (events: ISegregatedEvent<any>[]) {
+    return super.pushNewEvents(events)
+  }
+
+}

--- a/src/classes/repositories/EventRepository.ts
+++ b/src/classes/repositories/EventRepository.ts
@@ -14,8 +14,8 @@ export abstract class EventRepository<TEntity extends IEventEntity> {
   abstract async save (entity: TEntity, force?: Boolean): Promise<TEntity>
 
   abstract async findById (id: any): Promise<TEntity | null>
-    
+
   protected abstract async existBy (query: { [key: string]: any }): Promise<boolean>
 
-  abstract async _runPaginatedQuery (query: { [key: string]: any }, page: number, size: number, sort: { [field: string]: 1 | -1 }): Promise<IPaginatedQueryResult<{ events: IEvent<TEntity>[] }>>
+  abstract async _runPaginatedQuery (query: { [key: string]: any }, page: number, size: number, sort: { [field: string]: 1 | -1 }): Promise<IPaginatedQueryResult<{ events: IEvent<unknown>[] }>>
 }

--- a/src/classes/repositories/MongodbEventRepository.ts
+++ b/src/classes/repositories/MongodbEventRepository.ts
@@ -77,7 +77,7 @@ export abstract class MongodbEventRepository<TEntity extends IEventEntity> exten
    * @param {{[field: string]: 1|-1}} sort Fields to sort
    * @returns {Promise} Set of results
    */
-  async _runPaginatedQuery (query: { [key: string]: any }, page: number, size: number, sort: { [field: string]: 1 | -1 } = {}): Promise<IPaginatedQueryResult<{ events: IEvent<TEntity>[] }>> {
+  async _runPaginatedQuery (query: { [key: string]: any }, page: number, size: number, sort: { [field: string]: 1 | -1 } = {}): Promise<IPaginatedQueryResult<{ events: IEvent<unknown>[] }>> {
     const skip = (Number(page) - 1) * Number(size)
     const limit = Number(size)
 

--- a/src/classes/repositories/SegregatedMongodbEventRepository.ts
+++ b/src/classes/repositories/SegregatedMongodbEventRepository.ts
@@ -1,9 +1,9 @@
-import { IEntityConstructor } from '../../../dist'
 import { EventRepository } from './EventRepository'
 import { Collection, ObjectId, ClientSession } from 'mongodb'
 import { SegregatedEventEntity } from '../SegregatedEventEntity'
+import { ISegregatedEvent } from '../../interfaces/ISegregatedEvent'
+import { IEntityConstructor } from '../../interfaces/IEntityConstructor'
 import { IPaginatedQueryResult } from '../../interfaces/IPaginatedQueryResult'
-import { ISegregatedEvent } from '../../interfaces/ISegregatedEvent';
 
 interface IHashMap<T> {
   [key: string]: T[]

--- a/src/classes/repositories/SegregatedMongodbEventRepository.ts
+++ b/src/classes/repositories/SegregatedMongodbEventRepository.ts
@@ -1,0 +1,135 @@
+import { IEntityConstructor } from '../../../dist'
+import { EventRepository } from './EventRepository'
+import { Collection, ObjectId, ClientSession } from 'mongodb'
+import { SegregatedEventEntity } from '../SegregatedEventEntity'
+import { IPaginatedQueryResult } from '../../interfaces/IPaginatedQueryResult'
+import { ISegregatedEvent } from '../../interfaces/ISegregatedEvent';
+
+interface IHashMap<T> {
+  [key: string]: T[]
+}
+
+export class SegregatedMongodbEventRepository<TEntity extends SegregatedEventEntity<TEntity>> extends EventRepository<TEntity> {
+  protected readonly _stateCollection: Collection
+  protected readonly _eventCollection: Collection
+
+  constructor (stateCollection: Collection, eventCollection: Collection, Entity: IEntityConstructor<TEntity>) {
+    super(Entity)
+    this._stateCollection = stateCollection
+    this._eventCollection = eventCollection
+  }
+
+  /**
+   * Tries to execute function using given session
+   * @param {Function} fn Function to be executed
+   * @param {ClientSession} session MongoDB user session
+   * @returns {*} Function result
+   */
+  protected async _tryRunningWithSession (fn: Function, session: ClientSession) {
+    session.startTransaction()
+    try {
+      const result = await fn()
+      session.commitTransaction()
+      return result
+    } catch (err) {
+      session.abortTransaction()
+      throw err
+    }
+  }
+
+
+  async findById (id: string | ObjectId): Promise<TEntity | null> {
+    const events = await this._eventCollection.find({ entityId: new ObjectId(id) })
+      .toArray()
+
+    if (!events.length) {
+      return null
+    }
+
+    return new this._Entity().setPersistedEvents(events)
+  }
+
+  async hasEvents (query: { [ key: string ]: any }): Promise<boolean> {
+    return this._eventCollection.find(query)
+      .count()
+      .then(count => count > 0)
+  }
+
+  async hasState (query: { [ key: string ]: any }): Promise<boolean> {
+    return this._stateCollection.find(query)
+      .limit(1)
+      .count()
+      .then(count => count > 0)
+  }
+
+  async existBy (query: { [ key: string ]: any }): Promise<boolean> {
+    const [ hasEvents, hasState ] = await Promise.all([
+      this.hasEvents(query),
+      this.hasState(query)
+    ])
+
+    return hasEvents && hasState
+  }
+
+  private async _updateState (entity: TEntity, session?: ClientSession): Promise<TEntity> {
+    const { id: _id, ...state } = entity.state
+
+    await this._stateCollection.updateOne({ _id: entity.id }, {
+      $set: { _id, ...state }
+    }, { session })
+
+    return entity
+  }
+
+  async save (entity: TEntity, force: boolean = false, session?: ClientSession): Promise<TEntity> {
+    const events = force ? entity.events : entity.pendingEvents
+
+    if (force) await this._eventCollection.remove({ entityId: entity.id }, { session })
+
+    await this._eventCollection.insertMany(events, { ordered: true, session })
+
+    entity.confirmEvents()
+
+    if (await this.hasState({ _id: entity.id })) {
+      return this._updateState(entity, session)
+    }
+
+    await this._stateCollection.insertOne(entity.state, { session })
+
+    return entity
+  }
+
+  async _runPaginatedQuery (query: { [key: string]: any }, page: number, size: number, sort: { [field: string]: 1 | -1 } = {}): Promise<IPaginatedQueryResult<{ events: ISegregatedEvent<unknown>[] }>> {
+    const skip = (Number(page) - 1) * Number(size)
+    const limit = Number(size)
+
+    const total = await this._stateCollection.countDocuments(query)
+
+    if (total === 0) return { documents: [], count: 0, range: { from: 0, to: 0 }, total }
+
+    const entityIds = await this._stateCollection.find(query, { skip, limit, projection: { _id: 1 }, sort })
+      .toArray()
+      .then(states => states.map(({ _id }: { _id: ObjectId }) => _id.toHexString()))
+
+    const events = await this._eventCollection.find({ entityId: { $in: entityIds } }, { skip, limit, projection: { events: 1 }, sort }).toArray()
+
+    const eventsHashMap: IHashMap<ISegregatedEvent<unknown>> = events.reduce((hashMap: IHashMap<ISegregatedEvent<unknown>>, event: ISegregatedEvent<unknown>) => {
+      hashMap[event.entityId as string] = hashMap[event.entityId as any] || []
+      hashMap[event.entityId as string].push(event)
+      return hashMap
+    }, {})
+
+    const documents = Object.values(eventsHashMap).map(events => ({ events }))
+
+    const count = entityIds.length
+    const range = { from: skip, to: skip + count }
+
+    return { documents, count, range, total }
+  }
+
+  withSession (session: ClientSession) {
+    return {
+      save: (entity: TEntity, force: boolean = false) => this._tryRunningWithSession(() => this.save(entity, force, session), session)
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,19 @@
+export { Event, ICommitFunction, IEvent, Reducer } from '@nxcd/tardis'
+
+/**
+ * Classes
+ * =======
+ */
 export { EventEntity } from './classes/EventEntity'
-export { IEventEntity } from './interfaces/IEventEntity'
-
-export * from './classes/repositories/EventRepository'
-export { IPaginatedQueryResult } from './interfaces/IPaginatedQueryResult'
+export { SegregatedEventEntity } from './classes/SegregatedEventEntity'
+export { EventRepository } from './classes/repositories/EventRepository'
 export { MongodbEventRepository } from './classes/repositories/MongodbEventRepository'
+export { SegregatedMongodbEventRepository } from './classes/repositories/SegregatedMongodbEventRepository'
 
-export { Event, Reducer, IEvent, ICommitFunction } from '@nxcd/tardis'
+ /**
+  * Interfaces
+  */
+export { IEventEntity } from './interfaces/IEventEntity'
+export { ISegregatedEvent } from './interfaces/ISegregatedEvent'
+export { IEntityConstructor } from './interfaces/IEntityConstructor'
+export { IPaginatedQueryResult } from './interfaces/IPaginatedQueryResult'

--- a/src/interfaces/ISearchResult.ts
+++ b/src/interfaces/ISearchResult.ts
@@ -1,0 +1,9 @@
+export interface ISearchResult<Entity> {
+  entities: Entity[]
+  count: number
+  range: {
+    from: number
+    to: number
+  }
+  total: number
+}

--- a/src/interfaces/ISegregatedEvent.ts
+++ b/src/interfaces/ISegregatedEvent.ts
@@ -1,0 +1,5 @@
+import { IEvent } from '@nxcd/tardis'
+
+export interface ISegregatedEvent<TData> extends IEvent<TData> {
+    entityId: unknown
+}

--- a/src/interfaces/ISegregatedEvent.ts
+++ b/src/interfaces/ISegregatedEvent.ts
@@ -1,5 +1,5 @@
 import { IEvent } from '@nxcd/tardis'
 
 export interface ISegregatedEvent<TData> extends IEvent<TData> {
-    entityId: unknown
+    entityId: any
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es2015",
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",
+    "module": "es6",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "es6",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["es2017"],                             /* Specify library files to be included in the compilation. */
     "allowJs": false,
     /* Allow javascript files to be compiled. */
     "checkJs": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",
     /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     "removeComments": true,
     /* Do not emit comments to output. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es2015",
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "es6",
+    "module": "commonjs",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es2017"],                             /* Specify library files to be included in the compilation. */
     "allowJs": false,


### PR DESCRIPTION
### Changes
- Add `ISegreggatedEvent` wich defines an `entityId` property required for putting the events of an entity together

- Add `SegregatedMongodbEventRepository` wich only accepts dealing with `SegregatedEventEntity` instances

- Add `SegregatedEventEntity` wich requires `ISegregatedEvent`s instead of regular `Event`s on the constructor

### TODO:
- [ ] Add docs