### PR TITLE
Remove index signature from EventEntity

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,23 +1,24 @@
 dependencies:
-  '@nxcd/tardis': 2.0.1
-  '@types/mongodb': 3.1.22
-  '@types/node': 10.14.3
+  '@nxcd/tardis': 2.0.2
+  '@types/mongodb': 3.1.23
+  '@types/node': 10.14.4
 devDependencies:
   standard: 12.0.1
-  typescript: 3.3.4000
+  typescript: 3.4.3
+lockfileVersion: 5
 packages:
-  /@nxcd/tardis/2.0.1:
+  /@nxcd/tardis/2.0.2:
     dependencies:
       '@types/lodash.clonedeep': 4.5.6
-      '@types/node': 10.14.3
+      '@types/node': 10.14.4
       bson-objectid: 1.2.4
       lodash.clonedeep: 4.5.0
     dev: false
     resolution:
-      integrity: sha512-qhR2vAWeufcbCAeYa9L8kRlq20NdYgSicN4e9sGfDfM3Q6UrcT/OmAU+nUu6ERhOQFhKtvPu956ZgLT29Pd6tw==
+      integrity: sha512-MZWsUNTFT7xRNol0ABAYT3BePzuIK0FP3A0wDa3Z1zznUyvjnEHTCI8vV/BgyfGc/bMmB84Ze7EpT6AZIS/nRA==
   /@types/bson/4.0.0:
     dependencies:
-      '@types/node': 10.14.3
+      '@types/node': 10.14.4
     dev: false
     resolution:
       integrity: sha512-pq/rqJwJWkbS10crsG5bgnrisL8pML79KlMKQMoQwLUjlPAkrUHMvHJ3oGwE7WHR61Lv/nadMwXVAD2b+fpD8Q==
@@ -31,22 +32,21 @@ packages:
     dev: false
     resolution:
       integrity: sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
-  /@types/mongodb/3.1.22:
+  /@types/mongodb/3.1.23:
     dependencies:
       '@types/bson': 4.0.0
-      '@types/node': 10.14.3
+      '@types/node': 10.14.4
     dev: false
     resolution:
-      integrity: sha512-hvNR0txBlJJAy1eZOeIDshW4dnQaC694COou4eHHaMdIcteCfoCQATD7sYNlXxNxfTc1iIbHUi7A8CAhQe08uA==
-  /@types/node/10.14.3:
+      integrity: sha512-TNwS1HPh1nnaYorcQoWi+bH5kJ1Q/WqCjiD9XkU3oBeCZFYXXPafVUuFmoYFbzQ061ojhtsndRLzwNklRhU+4w==
+  /@types/node/10.14.4:
     dev: false
     resolution:
-      integrity: sha512-2lhc7S28vo8FwR3Jv3Ifyd77AxEsx+Nl9ajWiac6/eWuvZ84zPK4RE05pfqcn3acIzlZDpQj5F1rIKQZX3ptLQ==
-  /acorn-jsx/5.0.1/acorn@6.1.1:
+      integrity: sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
+  /acorn-jsx/5.0.1_acorn@6.1.1:
     dependencies:
       acorn: 6.1.1
     dev: true
-    id: registry.npmjs.org/acorn-jsx/5.0.1
     peerDependencies:
       acorn: ^6.0.0
     resolution:
@@ -58,11 +58,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
-  /ajv-keywords/3.4.0/ajv@6.10.0:
+  /ajv-keywords/3.4.0_ajv@6.10.0:
     dependencies:
       ajv: 6.10.0
     dev: true
-    id: registry.npmjs.org/ajv-keywords/3.4.0
     peerDependencies:
       ajv: ^6.9.1
     resolution:
@@ -227,7 +226,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.6.0
+      semver: 5.7.0
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
@@ -259,7 +258,7 @@ packages:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
   /define-properties/1.1.3:
     dependencies:
-      object-keys: 1.1.0
+      object-keys: 1.1.1
     dev: true
     engines:
       node: '>= 0.4'
@@ -306,7 +305,7 @@ packages:
       has: 1.0.3
       is-callable: 1.1.4
       is-regex: 1.0.4
-      object-keys: 1.1.0
+      object-keys: 1.1.1
     dev: true
     engines:
       node: '>= 0.4'
@@ -328,26 +327,24 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-  /eslint-config-standard-jsx/6.0.2/e60ea4cf0c907bef2e3b23660a172e14:
+  /eslint-config-standard-jsx/6.0.2_e60ea4cf0c907bef2e3b23660a172e14:
     dependencies:
       eslint: 5.4.0
-      eslint-plugin-react: /eslint-plugin-react/7.11.1/eslint@5.4.0
+      eslint-plugin-react: 7.11.1_eslint@5.4.0
     dev: true
-    id: registry.npmjs.org/eslint-config-standard-jsx/6.0.2
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-plugin-react: '>=7.11.1'
     resolution:
       integrity: sha512-D+YWAoXw+2GIdbMBRAzWwr1ZtvnSf4n4yL0gKGg7ShUOGXkSOLerI17K4F6LdQMJPNMoWYqepzQD/fKY+tXNSg==
-  /eslint-config-standard/12.0.0/c0bbbe1017bc0baddd63487521dd81b4:
+  /eslint-config-standard/12.0.0_c0bbbe1017bc0baddd63487521dd81b4:
     dependencies:
       eslint: 5.4.0
-      eslint-plugin-import: /eslint-plugin-import/2.14.0/eslint@5.4.0
-      eslint-plugin-node: /eslint-plugin-node/7.0.1/eslint@5.4.0
+      eslint-plugin-import: 2.14.0_eslint@5.4.0
+      eslint-plugin-node: 7.0.1_eslint@5.4.0
       eslint-plugin-promise: 4.0.1
-      eslint-plugin-standard: /eslint-plugin-standard/4.0.0/eslint@5.4.0
+      eslint-plugin-standard: 4.0.0_eslint@5.4.0
     dev: true
-    id: registry.npmjs.org/eslint-config-standard/12.0.0
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-plugin-import: '>=2.13.0'
@@ -372,7 +369,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
-  /eslint-plugin-es/1.4.0/eslint@5.4.0:
+  /eslint-plugin-es/1.4.0_eslint@5.4.0:
     dependencies:
       eslint: 5.4.0
       eslint-utils: 1.3.1
@@ -380,12 +377,11 @@ packages:
     dev: true
     engines:
       node: '>=6.5.0'
-    id: registry.npmjs.org/eslint-plugin-es/1.4.0
     peerDependencies:
       eslint: '>=4.19.1'
     resolution:
       integrity: sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==
-  /eslint-plugin-import/2.14.0/eslint@5.4.0:
+  /eslint-plugin-import/2.14.0_eslint@5.4.0:
     dependencies:
       contains-path: 0.1.0
       debug: 2.6.9
@@ -401,24 +397,22 @@ packages:
     dev: true
     engines:
       node: '>=4'
-    id: registry.npmjs.org/eslint-plugin-import/2.14.0
     peerDependencies:
       eslint: 2.x - 5.x
     resolution:
       integrity: sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==
-  /eslint-plugin-node/7.0.1/eslint@5.4.0:
+  /eslint-plugin-node/7.0.1_eslint@5.4.0:
     dependencies:
       eslint: 5.4.0
-      eslint-plugin-es: /eslint-plugin-es/1.4.0/eslint@5.4.0
+      eslint-plugin-es: 1.4.0_eslint@5.4.0
       eslint-utils: 1.3.1
       ignore: 4.0.6
       minimatch: 3.0.4
       resolve: 1.10.0
-      semver: 5.6.0
+      semver: 5.7.0
     dev: true
     engines:
       node: '>=6'
-    id: registry.npmjs.org/eslint-plugin-node/7.0.1
     peerDependencies:
       eslint: '>=4.19.1'
     resolution:
@@ -429,7 +423,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==
-  /eslint-plugin-react/7.11.1/eslint@5.4.0:
+  /eslint-plugin-react/7.11.1_eslint@5.4.0:
     dependencies:
       array-includes: 3.0.3
       doctrine: 2.1.0
@@ -440,16 +434,14 @@ packages:
     dev: true
     engines:
       node: '>=4'
-    id: registry.npmjs.org/eslint-plugin-react/7.11.1
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==
-  /eslint-plugin-standard/4.0.0/eslint@5.4.0:
+  /eslint-plugin-standard/4.0.0_eslint@5.4.0:
     dependencies:
       eslint: 5.4.0
     dev: true
-    id: registry.npmjs.org/eslint-plugin-standard/4.0.0
     peerDependencies:
       eslint: '>=5.0.0'
     resolution:
@@ -497,7 +489,7 @@ packages:
       imurmurhash: 0.1.4
       inquirer: 5.2.0
       is-resolvable: 1.1.0
-      js-yaml: 3.13.0
+      js-yaml: 3.13.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
       lodash: 4.17.11
@@ -510,7 +502,7 @@ packages:
       progress: 2.0.3
       regexpp: 2.0.1
       require-uncached: 1.0.3
-      semver: 5.6.0
+      semver: 5.7.0
       strip-ansi: 4.0.0
       strip-json-comments: 2.0.1
       table: 4.0.3
@@ -524,7 +516,7 @@ packages:
   /espree/4.1.0:
     dependencies:
       acorn: 6.1.1
-      acorn-jsx: /acorn-jsx/5.0.1/acorn@6.1.1
+      acorn-jsx: 5.0.1_acorn@6.1.1
       eslint-visitor-keys: 1.0.0
     dev: true
     engines:
@@ -816,14 +808,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
-  /js-yaml/3.13.0:
+  /js-yaml/3.13.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+      integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   /json-parse-better-errors/1.0.2:
     dev: true
     resolution:
@@ -950,7 +942,7 @@ packages:
     dependencies:
       hosted-git-info: 2.7.1
       resolve: 1.10.0
-      semver: 5.6.0
+      semver: 5.7.0
       validate-npm-package-license: 3.0.4
     dev: true
     resolution:
@@ -961,12 +953,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-  /object-keys/1.1.0:
+  /object-keys/1.1.1:
     dev: true
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
+      integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -1134,7 +1126,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react-is: 16.8.5
+      react-is: 16.8.6
     dev: true
     resolution:
       integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -1144,10 +1136,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-  /react-is/16.8.5:
+  /react-is/16.8.6:
     dev: true
     resolution:
-      integrity: sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
+      integrity: sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
   /read-pkg-up/2.0.0:
     dependencies:
       find-up: 2.1.0
@@ -1234,11 +1226,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-  /semver/5.6.0:
+  /semver/5.7.0:
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+      integrity: sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
   /shebang-command/1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -1268,7 +1260,7 @@ packages:
   /spdx-correct/3.1.0:
     dependencies:
       spdx-expression-parse: 3.0.0
-      spdx-license-ids: 3.0.3
+      spdx-license-ids: 3.0.4
     dev: true
     resolution:
       integrity: sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
@@ -1279,14 +1271,14 @@ packages:
   /spdx-expression-parse/3.0.0:
     dependencies:
       spdx-exceptions: 2.2.0
-      spdx-license-ids: 3.0.3
+      spdx-license-ids: 3.0.4
     dev: true
     resolution:
       integrity: sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
-  /spdx-license-ids/3.0.3:
+  /spdx-license-ids/3.0.4:
     dev: true
     resolution:
-      integrity: sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
+      integrity: sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
   /sprintf-js/1.0.3:
     dev: true
     resolution:
@@ -1303,13 +1295,13 @@ packages:
   /standard/12.0.1:
     dependencies:
       eslint: 5.4.0
-      eslint-config-standard: /eslint-config-standard/12.0.0/c0bbbe1017bc0baddd63487521dd81b4
-      eslint-config-standard-jsx: /eslint-config-standard-jsx/6.0.2/e60ea4cf0c907bef2e3b23660a172e14
-      eslint-plugin-import: /eslint-plugin-import/2.14.0/eslint@5.4.0
-      eslint-plugin-node: /eslint-plugin-node/7.0.1/eslint@5.4.0
+      eslint-config-standard: 12.0.0_c0bbbe1017bc0baddd63487521dd81b4
+      eslint-config-standard-jsx: 6.0.2_e60ea4cf0c907bef2e3b23660a172e14
+      eslint-plugin-import: 2.14.0_eslint@5.4.0
+      eslint-plugin-node: 7.0.1_eslint@5.4.0
       eslint-plugin-promise: 4.0.1
-      eslint-plugin-react: /eslint-plugin-react/7.11.1/eslint@5.4.0
-      eslint-plugin-standard: /eslint-plugin-standard/4.0.0/eslint@5.4.0
+      eslint-plugin-react: 7.11.1_eslint@5.4.0
+      eslint-plugin-standard: 4.0.0_eslint@5.4.0
       standard-engine: 9.0.0
     dev: true
     engines:
@@ -1377,7 +1369,7 @@ packages:
   /table/4.0.3:
     dependencies:
       ajv: 6.10.0
-      ajv-keywords: /ajv-keywords/3.4.0/ajv@6.10.0
+      ajv-keywords: 3.4.0_ajv@6.10.0
       chalk: 2.4.2
       lodash: 4.17.11
       slice-ansi: 1.0.0
@@ -1411,13 +1403,13 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
-  /typescript/3.3.4000:
+  /typescript/3.4.3:
     dev: true
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+      integrity: sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
   /uniq/1.0.1:
     dev: true
     resolution:
@@ -1464,9 +1456,6 @@ packages:
       node: '>=0.4'
     resolution:
       integrity: sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
-registry: 'https://registry.npmjs.org/'
-shrinkwrapMinorVersion: 9
-shrinkwrapVersion: 3
 specifiers:
   '@nxcd/tardis': ^2.0.1
   '@types/mongodb': ^3.1.22

--- a/src/classes/EventEntity.ts
+++ b/src/classes/EventEntity.ts
@@ -1,8 +1,7 @@
-import { IEvent, Reducer, ICommitFunction } from '@nxcd/tardis'
 import { IEventEntity } from '../interfaces/IEventEntity'
+import { IEvent, Reducer, ICommitFunction } from '@nxcd/tardis'
 
 export abstract class EventEntity<TEntity> implements IEventEntity {
-  [key: string]: any
   persistedEvents: IEvent<any>[] = []
   pendingEvents: IEvent<any>[] = []
   id: any = null
@@ -21,7 +20,7 @@ export abstract class EventEntity<TEntity> implements IEventEntity {
     const state = this.state
 
     for (const propertyName of Object.keys(state)) {
-      this[propertyName] = state[propertyName]
+      (this as any)[propertyName] = state[propertyName]
     }
   }
 


### PR DESCRIPTION
As suggested in #5, `EventEntity` should not have an index signature as this allows users to access non-existing properties on their entities.

Two solutions were proposed:
1. Add a `//@ts-ignore` comment above `this[propertyName]`
2. Cast `this` to `any` before accessing the property

I chose the second one, since I find it to be more elegant overall

closes #5